### PR TITLE
[Docs] Correctly indent PyPI docs.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,22 +50,22 @@ Issues = "https://github.com/OpenAssetIO/OpenAssetIO/issues"
 # PyPI. Instead, boil down the first couple of sections to give a brief
 # overview.
 text = """
-    In modern creative pipelines, data is often managed by an authoritative system (Asset\
-    Management System, Digital Asset Manager, MAM, et. al).
+In modern creative pipelines, data is often managed by an authoritative system (Asset\
+Management System, Digital Asset Manager, MAM, et. al).
 
-    It is common for media creation tools to reference this managed data by its present location\
-    in a file system.
+It is common for media creation tools to reference this managed data by its present location\
+in a file system.
 
-    OpenAssetIO enables tools to reference managed data by identity (using an "Entity Reference")\
-    instead of a file system path.
+OpenAssetIO enables tools to reference managed data by identity (using an "Entity Reference")\
+instead of a file system path.
 
-    This is achieved through the definition of a common set of interactions between a host of the\
-    API (eg: a Digital Content Creation tool or pipeline script) and an Asset Management System.
+This is achieved through the definition of a common set of interactions between a host of the\
+API (eg: a Digital Content Creation tool or pipeline script) and an Asset Management System.
 
-    This common API surface area removes the need for common pipeline business logic to be\
-    re-implemented against the native API of each tool, and allows the tools themselves to design\
-    new workflows that streamline the creation of complex assets.\
-    """
+This common API surface area removes the need for common pipeline business logic to be\
+re-implemented against the native API of each tool, and allows the tools themselves to design\
+new workflows that streamline the creation of complex assets.\
+"""
 content-type = "text/markdown"
 
 [tool.pylint.messages_control]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openassetio"
-version = "1.0.0a5"
+version = "1.0.0a32-dev"
 requires-python = ">=3.9"
 
 authors = [


### PR DESCRIPTION
The indentation was causing the markdown formatting not to be appplied correctly.

Signed-off-by: Elliot Morris <elliot.morris@foundry.com>