### PR TITLE
[Core] Remove [[nodiscard]] from getTraitProperty

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,9 +14,16 @@ v1.0.0-alpha.X
 
 - Added `TraitBase.isImbuedTo` static/class method, giving a cheaper
   mechanism for testing whether a `TraitsData` is imbued with a trait.
-  [#815](https://github.com/OpenAssetIO/OpenAssetIO/issues/815)
+  [#815](https://github.com/OpenAssetIO/OpenAssetIO/issues/815)z
 
+### Bug fixes
 
+- Removed `nodiscard` from `TraitsData::getTraitProperty`, and
+  `TraitBase::getTraitProperty`, to allow "value or default" style use
+  cases.
+  [#825](https://github.com/OpenAssetIO/OpenAssetIO/issues/825)
+
+  
 v1.0.0-alpha.9
 --------------
 

--- a/src/openassetio-core/include/openassetio/TraitsData.hpp
+++ b/src/openassetio-core/include/openassetio/TraitsData.hpp
@@ -132,8 +132,8 @@ class OPENASSETIO_CORE_EXPORT TraitsData final {
    * @exception `std::out_of_range` if this instance does not have
    * this trait.
    */
-  [[nodiscard]] bool getTraitProperty(trait::property::Value* out, const trait::TraitId& traitId,
-                                      const trait::property::Key& propertyKey) const;
+  bool getTraitProperty(trait::property::Value* out, const trait::TraitId& traitId,
+                        const trait::property::Key& propertyKey) const;
 
   /**
    * Set the value of given trait property.

--- a/src/openassetio-core/include/openassetio/trait/TraitBase.hpp
+++ b/src/openassetio-core/include/openassetio/trait/TraitBase.hpp
@@ -146,8 +146,8 @@ struct TraitBase {
    * @return Status of property in the underlying data.
    */
   template <class T>
-  [[nodiscard]] TraitPropertyStatus getTraitProperty(T* out, const TraitId& traitId,
-                                                     const property::Key& propertyKey) const {
+  TraitPropertyStatus getTraitProperty(T* out, const TraitId& traitId,
+                                       const property::Key& propertyKey) const {
     if (property::Value value; data()->getTraitProperty(&value, traitId, propertyKey)) {
       if (T* maybeOut = std::get_if<T>(&value)) {
         *out = *maybeOut;


### PR DESCRIPTION
The value of `getTraitProperty` is returned via an out param. It's actual return value is merely a status flag.

It's possible the user may wish to employ a "value or default" style, which would not be possible with [[nodiscard]]

## Description

Closes # (issue)

- [ ] I have updated the release notes.
- [ ] I have updated all relevant user documentation.

## Reviewer Notes

<!--- Provide any notes to the reviewer that might help them more easily
      understand the changeset. --->

## Test Instructions

<!--- Provide instructions to the reviewer on how to explicitly test
      these changes. --->
