### PR TITLE
[Core] Add python conversion functions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,6 +38,11 @@ v1.0.0-alpha.xx
 
 ### Improvements
 
+- Added `openassetio.internal.python-bridge-no-openassetio-module-test`
+  ctest project to support testing python interop functions in an
+  environment without the `openassetio` module loaded.
+  [#798](https://github.com/OpenAssetIO/OpenAssetIO/issues/798)
+
 - Added support for running `ctest` when a python venv is used to
   determine which Python distribution to build against.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,6 +29,13 @@ v1.0.0-alpha.xx
   `ResolveSuccessCallback` from reference types to value types.
   [#858](https://github.com/OpenAssetIO/OpenAssetIO/issues/858)
 
+### New Features
+
+- Added utility methods `castToPyObject` and `castFromPyObject` to
+  facilitate converting between cpp and python objects for hosts
+  seeking to support mixed language workflows.
+  [#798](https://github.com/OpenAssetIO/OpenAssetIO/issues/798)
+
 ### Improvements
 
 - Added support for running `ctest` when a python venv is used to

--- a/src/openassetio-python/bridge/CMakeLists.txt
+++ b/src/openassetio-python/bridge/CMakeLists.txt
@@ -55,7 +55,8 @@ endif ()
 # Source file dependencies.
 target_sources(openassetio-python-bridge
     PRIVATE
-    src/python/hostApi.cpp)
+    src/python/hostApi.cpp
+    src/python/converter/converters.cpp)
 
 # Public header dependency.
 target_include_directories(openassetio-python-bridge

--- a/src/openassetio-python/bridge/include/openassetio/python/converter/converters.hpp
+++ b/src/openassetio-python/bridge/include/openassetio/python/converter/converters.hpp
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+#pragma once
+
+#include <Python.h>
+
+#include <openassetio/export.h>
+#include <openassetio/python/export.h>
+#include <openassetio/typedefs.hpp>
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+/**
+ * Converter functionality for going between C++ and CPython objects.
+ */
+namespace python::converter {
+/**
+ * Casts a C++ API object to the equivalent Python object.
+ *
+ * This template is explicitly instantiated to only the OpenAssetIO
+ * types, and is not intended to be a generic converter.
+ *
+ * The purpose of this function is allow Python/C++ conversion whilst
+ * hiding the pybind11 dependency, allowing consumers to retrieve a
+ * Python object without having to have pybind in their build stack. A
+ * pybind cast is done behind the scenes, returning the released ptr
+ * from that.
+ *
+ * @note This function does not acquire the GIL.
+ *
+ * @warning A Python environment, with openassetio imported, must be
+ *          available in order to use this function.
+ *
+ * @throws std::invalid_argument if the input is null.
+ * @throws std::runtime_error if the cast fails. The .what() of this
+ *         exception is the Python exception string.
+ *
+ * @param objectPtr An OpenAssetIO pointer type, (eg, @needsref
+ * ManagerPtr). The returned pointer takes shared ownership of this
+ * input \p objectPtr, and will keep the c++ instance alive until the
+ * `PyObject` is destroyed.
+ *
+ * @return A `PyObject` pointer to an object of the Python api type
+ * associated with the c++ api object provided.
+ * The pointer is not an RAII type, and will be returned with an
+ * incremented reference count for the caller to manage,  and must
+ * must be released via `Py_DECREF` or similar mechanisms.
+ */
+template <typename T>
+OPENASSETIO_PYTHON_BRIDGE_EXPORT PyObject* castToPyObject(const T& objectPtr);
+
+/**
+ * Casts a Python object to the equivalent C++ Api object.
+ *
+ * This template is explicitly instantiated to only the OpenAssetIO
+ * types, and is not intended to be a generic converter.
+ *
+ * The purpose of this function is to Python/C++ conversion whilst
+ * hiding the pybind11 dependency, allowing consumers to retrieve a
+ * Python object without having to have pybind in their build stack. A
+ * pybind cast is done behind the scenes, returning the C++ object
+ * pointer from that.
+ *
+ * This function will increment the reference count of the provided
+ * Python object for the lifetime of the returned C++ object.
+ * When the returned C++ object falls out of scope or is otherwise
+ * cleaned up, the Python object will have its reference count reduced
+ * by one, potentially invoking cleanup.
+ *
+ * Using this function requires specifying the template argument of
+ * the C++ API type equivalent to the type of the object referred to by
+ * the \p pyObject pointer.
+ *
+ * @code{.cpp}
+ * ManagerPtr manager = castFromPyObject<Manager>(pyManager);
+ * @endcode
+ *
+ *
+ * If the types of the template argument and the \p pyObject are not
+ * equivalent, an exception will be thrown due to inability to perform
+ * the cast.
+ *
+ * @note This function does not acquire the GIL.
+ *
+ * @warning A Python environment, with openassetio imported, must be
+ *          available in order to use this function.
+ *
+ * @throws std::invalid_argument if the function fails due to inability
+ * to cast between types, or if the input is null.
+ *
+ * @param pyObject A `PyObject` pointer to a Python object that must be
+ * of equivalent type to the template argument.
+ *
+ * @return An OpenAssetIO pointer to a C++ API object cast from the
+ * provided \p pyObject. The lifetime of the PyObject will be extended
+ * to at least the lifetime of the returned C++ object.
+ */
+template <typename T>
+OPENASSETIO_PYTHON_BRIDGE_EXPORT typename T::Ptr castFromPyObject(PyObject* pyObject);
+
+}  // namespace python::converter
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-python/bridge/src/python/converter/converters.cpp
+++ b/src/openassetio-python/bridge/src/python/converter/converters.cpp
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 The Foundry Visionmongers Ltd
+#include <openassetio/python/converter/converters.hpp>
+
+#include <pybind11/embed.h>
+
+#include <openassetio/Context.hpp>
+#include <openassetio/TraitsData.hpp>
+#include <openassetio/hostApi/HostInterface.hpp>
+#include <openassetio/hostApi/Manager.hpp>
+#include <openassetio/hostApi/ManagerFactory.hpp>
+#include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
+#include <openassetio/log/ConsoleLogger.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
+#include <openassetio/log/SeverityFilter.hpp>
+#include <openassetio/managerApi/Host.hpp>
+#include <openassetio/managerApi/HostSession.hpp>
+#include <openassetio/managerApi/ManagerInterface.hpp>
+#include <openassetio/managerApi/ManagerStateBase.hpp>
+
+// Private headers
+#include <openassetio/private/python/pointers.hpp>
+
+namespace py = pybind11;
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace python::converter {
+
+template <typename T>
+PyObject* castToPyObject(const T& objectPtr) {
+  // Stash the errors for restoring after cast.
+  // An error_scope calls PyErr_Fetch (which clears the active error),
+  // and stashes them, restoring the error state when it falls out of
+  // scope
+  py::error_scope errorScope;
+
+  if (objectPtr == nullptr) {
+    throw std::invalid_argument("objectPtr cannot be null");
+  }
+
+  py::object pybindObj = py::cast(objectPtr);
+
+  // Check to see if the py::cast has spawned a python error
+  // We use another error_scope here for convenience of access, relying
+  // on the fact that the original error scope will be destructed last,
+  // resetting to the initial error.
+  py::error_scope errors;
+
+  if (errors.value != nullptr) {
+    throw std::runtime_error(py::str(errors.value));
+  }
+
+  return pybindObj.release().ptr();
+}
+
+template <typename T>
+typename T::Ptr castFromPyObject(PyObject* pyObject) {
+  if (pyObject == nullptr) {
+    throw std::invalid_argument("pyObject cannot be null");
+  }
+
+  // get Python object.
+  const auto pyInstance = py::reinterpret_borrow<py::object>(pyObject);
+
+  try {
+    // Extract the underlying C++ base class pointer.
+    auto* cppInstancePtr = py::cast<T*>(pyInstance);
+
+    // Use aliasing constructor, linking Python instance and C++ instance
+    // lifetimes via PyObject refcount.
+    return pointers::createPyRetainingPtr<typename T::Ptr>(pyInstance, cppInstancePtr);
+  } catch (const py::cast_error& castError) {
+    // Rethrow here to avoid bleeding pybind exception dependencies.
+    throw std::invalid_argument(castError.what());
+  }
+}
+
+// To/from explicit specialization convenience.
+// As these specializations are being used across library boundaries,
+// we must export them to prevent undefined-symbol link errors.
+#define OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(Class)                          \
+  template OPENASSETIO_PYTHON_BRIDGE_EXPORT PyObject* castToPyObject<Class::Ptr>( \
+      const Class::Ptr&);                                                         \
+  template OPENASSETIO_PYTHON_BRIDGE_EXPORT Class::Ptr castFromPyObject<Class>(PyObject*);
+
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(openassetio::Context)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(openassetio::TraitsData)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(hostApi::HostInterface)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(hostApi::Manager)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(hostApi::ManagerFactory)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(hostApi::ManagerImplementationFactoryInterface)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(log::ConsoleLogger)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(log::LoggerInterface)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(log::SeverityFilter)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(managerApi::Host)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(managerApi::HostSession)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(managerApi::ManagerInterface)
+OPENASSETIO_SPECIALIZE_PYTHON_CONVERSIONS(managerApi::ManagerStateBase)
+
+}  // namespace python::converter
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio

--- a/src/openassetio-python/tests/bridge/CMakeLists.txt
+++ b/src/openassetio-python/tests/bridge/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(
     openassetio-python-bridge-test-exe
     PRIVATE
     main.cpp
+    python/test_converters.cpp
     python/test_hostApi.cpp
 )
 
@@ -97,7 +98,7 @@ separate_arguments(_envvars NATIVE_COMMAND ${_envvars})
 
 
 #-----------------------------------------------------------------------
-# Create CTest target.
+# Create CTest target for tests that may import _openassetio
 add_custom_target(
     openassetio.internal.python-bridge-test
     COMMAND
@@ -116,5 +117,28 @@ $<TARGET_FILE_NAME:openassetio-python-bridge-test-exe>"
 openassetio_add_test_target(openassetio.internal.python-bridge-test)
 openassetio_add_test_fixture_dependencies(
     openassetio.internal.python-bridge-test
+    openassetio.internal.install
+)
+
+#-----------------------------------------------------------------------
+# Create CTest target for tests that intentionally exclude _openassetio
+add_custom_target(
+    openassetio.internal.python-bridge-no-openassetio-module-test
+    COMMAND
+    # Note: environment variables set in-line here rather than using
+    # `set_tests_properties`. If that function is used then the calling
+    # environment is affected. In particular, PYTHONHOME can interfere
+    # with CMake itself (if installed as a pip package and so
+    # /usr/local/cmake is actually a Python console_script).
+    # Note: as above, we must not have trailing whitespace after setting
+    # an env var on Windows.
+    ${_envvars}&&
+"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/\
+$<TARGET_FILE_NAME:openassetio-python-bridge-test-exe>" "[no_openassetio_module]"
+)
+
+openassetio_add_test_target(openassetio.internal.python-bridge-no-openassetio-module-test)
+openassetio_add_test_fixture_dependencies(
+    openassetio.internal.python-bridge-no-openassetio-module-test
     openassetio.internal.install
 )

--- a/src/openassetio-python/tests/bridge/lsan_suppressions.txt
+++ b/src/openassetio-python/tests/bridge/lsan_suppressions.txt
@@ -1,3 +1,6 @@
 # pybind11 leak when defining enums
 # https://github.com/pybind/pybind11/issues/3865
 leak:pybind11::enum_<
+# Dynamic static initialization avoiding static deinitialization fiasco
+# https://github.com/pybind/pybind11/pull/4192#discussion_r975991726
+leak:pybind11::detail::get_local_internals()

--- a/src/openassetio-python/tests/bridge/python/test_converters.cpp
+++ b/src/openassetio-python/tests/bridge/python/test_converters.cpp
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2023 The Foundry Visionmongers Ltd
+
+#include <pybind11/embed.h>
+
+#include <openassetio/export.h>
+
+#include <catch2/catch.hpp>
+#include <catch2/trompeloeil.hpp>
+
+#include <openassetio/python/converter/converters.hpp>
+
+#include <openassetio/Context.hpp>
+#include <openassetio/TraitsData.hpp>
+#include <openassetio/hostApi/HostInterface.hpp>
+#include <openassetio/hostApi/Manager.hpp>
+#include <openassetio/hostApi/ManagerFactory.hpp>
+#include <openassetio/hostApi/ManagerImplementationFactoryInterface.hpp>
+#include <openassetio/log/ConsoleLogger.hpp>
+#include <openassetio/log/LoggerInterface.hpp>
+#include <openassetio/log/SeverityFilter.hpp>
+#include <openassetio/managerApi/Host.hpp>
+#include <openassetio/managerApi/HostSession.hpp>
+#include <openassetio/managerApi/ManagerInterface.hpp>
+#include <openassetio/managerApi/ManagerStateBase.hpp>
+#include <openassetio/python/hostApi.hpp>
+
+namespace py = pybind11;
+
+namespace openassetio {
+inline namespace OPENASSETIO_CORE_ABI_VERSION {
+namespace {
+constexpr const char* kTestTraitId = "TestTrait";
+}  // namespace
+
+SCENARIO("Mutations in one language are reflected in the other") {
+  // Cause the openassetio-python lib to be loaded so pybind can cast.
+  py::module_::import("openassetio");
+
+  GIVEN("A C++ object casted to a python object") {
+    TraitsDataPtr traitsData = TraitsData::make();
+    PyObject* pyTraitsData = openassetio::python::converter::castToPyObject(traitsData);
+    REQUIRE(pyTraitsData != nullptr);
+
+    WHEN("Data is set via the c++ object") {
+      traitsData->addTrait(kTestTraitId);
+
+      THEN("The python object reflects that data set.") {
+        PyObject* resultBool = PyObject_CallMethod(pyTraitsData, "hasTrait", "s", kTestTraitId);
+
+        // Use CHECK rather than REQUIRE in order to ensure the Decrefs
+        // below actually execute.
+        CHECK(PyBool_Check(resultBool));
+        CHECK(PyObject_IsTrue(resultBool));
+        Py_DECREF(resultBool);
+      }
+    }
+    WHEN("Data is set via the python object") {
+      PyObject_CallMethod(pyTraitsData, "addTrait", "s", kTestTraitId);
+      CHECK(traitsData->hasTrait("") == false);
+    }
+    Py_DECREF(pyTraitsData);
+  }
+  GIVEN("A python object casted to a C++ object") {
+    const py::object pyClass = py::module_::import("openassetio").attr("TraitsData");
+    py::object pyInstance = pyClass();
+    PyObject* pyTraitsData = pyInstance.release().ptr();
+    TraitsDataPtr traitsData =
+        openassetio::python::converter::castFromPyObject<TraitsData>(pyTraitsData);
+
+    WHEN("Data is set via the c++ object") {
+      traitsData->addTrait(kTestTraitId);
+
+      THEN("The python object reflects that data set.") {
+        PyObject* resultBool = PyObject_CallMethod(pyTraitsData, "hasTrait", "s", kTestTraitId);
+
+        // Use CHECK rather than REQUIRE in order to ensure the Decrefs
+        // below actually execute.
+        CHECK(PyBool_Check(resultBool));
+        CHECK(PyObject_IsTrue(resultBool));
+        Py_DECREF(resultBool);
+      }
+    }
+    WHEN("Data is set via the python object") {
+      PyObject_CallMethod(pyTraitsData, "addTrait", "s", kTestTraitId);
+      CHECK(traitsData->hasTrait("") == false);
+    }
+    Py_DECREF(pyTraitsData);
+  }
+}
+
+SCENARIO("Casting to PyObject extends object lifetime") {
+  GIVEN("A python object casted from a C++ object") {
+    WHEN("The C++ object falls out of scope") {
+      PyObject* pyTraitsData = nullptr;
+      {
+        TraitsDataPtr traitsData = TraitsData::make();
+        traitsData->addTrait(kTestTraitId);
+        pyTraitsData = openassetio::python::converter::castToPyObject(traitsData);
+        CHECK(Py_REFCNT(pyTraitsData) == 1);
+      }
+      THEN("The python object remains alive and can be operated on via the python interpreter") {
+        CHECK(Py_REFCNT(pyTraitsData) == 1);
+        PyObject* resultBool = PyObject_CallMethod(pyTraitsData, "hasTrait", "s", kTestTraitId);
+
+        // Use CHECK rather than REQUIRE in order to ensure the Decrefs
+        // below actually execute.
+        CHECK(PyBool_Check(resultBool));
+        CHECK(PyObject_IsTrue(resultBool));
+        Py_DECREF(resultBool);
+      }
+      Py_DECREF(pyTraitsData);
+    }
+  }
+}
+
+SCENARIO("Casting to a C++ object binds object lifetime") {
+  GIVEN("A python object") {
+    py::module_::import("openassetio");
+
+    // Create a python object and release it, to simulate an unmanaged
+    // PyObject being provided to us.
+    const py::object pyClass = py::module_::import("openassetio").attr("TraitsData");
+    py::object pyInstance = pyClass();
+    PyObject* pyTraitsData = pyInstance.release().ptr();
+    CHECK(Py_REFCNT(pyTraitsData) == 1);
+
+    WHEN("The python object is converted to a C++ object") {
+      TraitsDataPtr traitsData =
+          openassetio::python::converter::castFromPyObject<TraitsData>(pyTraitsData);
+
+      THEN("The python reference count has been increased") {
+        CHECK(Py_REFCNT(pyTraitsData) == 2);
+      }
+    }
+    AND_WHEN("The c++ object falls out of scope") {
+      THEN("The python reference count is reduced") { CHECK(Py_REFCNT(pyTraitsData) == 1); }
+    }
+    Py_DECREF(pyTraitsData);
+  }
+}
+
+SCENARIO("Attempting to cast to an unregistered type") {
+  GIVEN("an invalid for casting python object") {
+    // Create a python object and release it, to simulate an unmanaged
+    // PyObject being provided to us.
+    py::object pyClass = py::module_::import("decimal").attr("Decimal");
+    py::object pyInstance = pyClass(1.0);
+    // PyDecimal is not a type pybind has been registered to convert.
+    PyObject* pyDecimal = pyInstance.release().ptr();
+
+    /*
+     * Pybind error messages vary between release and debug mode:
+     * "Unable to cast Python instance of type <class 'decimal.Decimal'> to C++
+     * type 'openassetio::v1::hostApi::Manager'"
+     * vs.
+     * "Unable to cast Python instance to C++ type (compile in debug
+     * mode for details)"
+     */
+    WHEN("The object is converted to a C++ object") {
+      REQUIRE_THROWS_WITH(
+          openassetio::python::converter::castFromPyObject<openassetio::hostApi::Manager>(
+              pyDecimal),
+          Catch::Matchers::StartsWith("Unable to cast Python instance"));
+    }
+
+    Py_DECREF(pyDecimal);
+  }
+}
+
+SCENARIO("Converting from C++ API Objects to Python API Objects without openassetio module loaded",
+         "[.][no_openassetio_module]") {
+  GIVEN("A python environment without openassetio loaded") {
+    const TraitsDataPtr traitsData = TraitsData::make();
+    WHEN("An OpenAssetIO type is casted to a python object") {
+      THEN("The cast throws an exception") {
+        REQUIRE_THROWS_WITH(openassetio::python::converter::castToPyObject(traitsData),
+                            std::string("Unregistered type : openassetio::v1::TraitsData"));
+      }
+    }
+  }
+
+  GIVEN("A CPython error state is already set") {
+    // If the process terminates with a CPython error, pybind will emit
+    // an exception on destruction, causing a terminate call.
+    // As we explicitly set an error in this test, use a scope to make
+    // sure we clean up after ourselves.
+    py::error_scope errorCleanup;
+
+    const std::string errorString = "Test Error";
+    // Set the CPython exception.
+    PyErr_SetString(PyExc_RuntimeError, errorString.c_str());
+    WHEN("The cpp object is casted to a python object") {
+      THEN("The cast throws the expected exception") {
+        const TraitsDataPtr traitsData = TraitsData::make();
+        REQUIRE_THROWS_WITH(openassetio::python::converter::castToPyObject(traitsData),
+                            std::string("Unregistered type : openassetio::v1::TraitsData"));
+      }
+      AND_THEN("The CPython error state is maintained") {
+        // castToPyObject, despite messing with the PyErr state itself,
+        // should have correctly reset the exception back.
+        REQUIRE(PyErr_ExceptionMatches(PyExc_RuntimeError));
+        py::error_scope errors;
+        REQUIRE(std::string(py::str(errors.value)) == errorString);
+      }
+    }
+  }
+}
+
+namespace {
+
+#define CLASS_AND_PTRS(Class) std::tuple<Class, Class##Ptr, Class##ConstPtr>
+
+namespace hostApi = openassetio::hostApi;
+namespace log = openassetio::log;
+namespace managerApi = openassetio::managerApi;
+
+// clang-format off
+
+using ClassesWithPtrAlias = std::tuple<
+    CLASS_AND_PTRS(openassetio::Context),
+    CLASS_AND_PTRS(openassetio::TraitsData),
+    CLASS_AND_PTRS(hostApi::HostInterface),
+    CLASS_AND_PTRS(hostApi::Manager),
+    CLASS_AND_PTRS(hostApi::ManagerFactory),
+    CLASS_AND_PTRS(hostApi::ManagerImplementationFactoryInterface),
+    CLASS_AND_PTRS(log::ConsoleLogger),
+    CLASS_AND_PTRS(log::LoggerInterface),
+    CLASS_AND_PTRS(log::SeverityFilter),
+    CLASS_AND_PTRS(managerApi::Host),
+    CLASS_AND_PTRS(managerApi::HostSession),
+    CLASS_AND_PTRS(managerApi::ManagerInterface),
+    CLASS_AND_PTRS(managerApi::ManagerStateBase)
+>;
+}  // namespace
+
+// clang-format on
+TEMPLATE_LIST_TEST_CASE("Appropriate classes have castFromPyObject functions", "",
+                        ClassesWithPtrAlias) {
+  using Class = std::tuple_element_t<0, TestType>;
+
+  // These tests check that the nullptr exception works, but also
+  // serve to verify that the functions exist for all expected types.
+  PyObject* empty = nullptr;
+  REQUIRE_THROWS_WITH(openassetio::python::converter::castFromPyObject<Class>(empty),
+                      std::string("pyObject cannot be null"));
+}
+
+TEMPLATE_LIST_TEST_CASE("Appropriate classes have castToPyObject functions", "",
+                        ClassesWithPtrAlias) {
+  using ClassPtr = std::tuple_element_t<1, TestType>;
+
+  // These tests check that the nullptr exception works, but also
+  // serve to verify that the functions exist for all expected types.
+  ClassPtr empty = nullptr;
+  REQUIRE_THROWS_WITH(openassetio::python::converter::castToPyObject(empty),
+                      std::string("objectPtr cannot be null"));
+}
+}  // namespace OPENASSETIO_CORE_ABI_VERSION
+}  // namespace openassetio


### PR DESCRIPTION
[#798] There is a need as a hybrid C++/Python host application author to convert types between an embedded python interpreter and a c++ context, as some hosts will want to do asset resolution in both languages, sharing the same configuration.

This adds two methods to python bridge, `castToPyObject` and `castFromPyObject` that facilitates this.

Prior, the way to do this was to do a pybind cast, which is what we do here behind the scenes, but by providing methods to raw CPython types, we eliminate the need to link against pybind for the consumer.

## Description

Closes # (issue)

- [ ] I have updated the release notes.
- [ ] I have updated all relevant user documentation.

## Reviewer Notes

<!--- Provide any notes to the reviewer that might help them more easily
      understand the changeset. --->

## Test Instructions

<!--- Provide instructions to the reviewer on how to explicitly test
      these changes. --->
