### PR TITLE
[Core] Remove retention from context

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,6 +36,9 @@ v1.0.0-alpha.x
   out-param based.
   [#996](https://github.com/OpenAssetIO/OpenAssetIO/issues/996)
 
+- Removed `Context.Retention`.
+  [#1048](https://github.com/OpenAssetIO/OpenAssetIO/issues/1048)
+
 ### New Features
 
 - Added `Context.Access.kCreateRelated` access pattern, to  indicate

--- a/src/openassetio-core/include/openassetio/Context.hpp
+++ b/src/openassetio-core/include/openassetio/Context.hpp
@@ -76,23 +76,6 @@ class OPENASSETIO_CORE_EXPORT Context final {
   /// @}
 
   /**
-   * @name Data Retention
-   */
-  enum class Retention {
-    /// Data will not be used
-    kIgnored,
-    /// Data will be re-used during a particular action
-    kTransient,
-    /// Data will be stored and re-used for the session
-    kSession,
-    /// Data will be permanently stored in the document
-    kPermanent
-  };
-
-  static constexpr std::array kRetentionNames{"ignored", "transient", "session", "permanent"};
-  /// @}
-
-  /**
    * Describes what the @ref host is intending to do with the data.
    *
    * For example, when passed to resolve, it specifies if the @ref host
@@ -103,28 +86,6 @@ class OPENASSETIO_CORE_EXPORT Context final {
    * See also @ref create_related "Create related glossary entry".
    */
   Access access;
-
-  /**
-   * A concession to the fact that it's not always possible to fully
-   * implement the spec of this API within a @ref host.
-   *
-   * For example, @fqref{managerApi.ManagerInterface.register_}
-   * "Manager.register()" can return an @ref entity_reference that
-   * points to the newly published @ref entity. This is often not the
-   * same as the reference that was passed to the call. The Host is
-   * expected to store this new reference for future use. For example
-   * in the case of a Scene File added to an 'open recent' menu. A
-   * Manager may rely on this to ensure a reference that points to a
-   * specific version is used in the future.
-   *
-   * In some cases - such as batch rendering of an image sequence,
-   * it may not be possible to store this final reference, due to
-   * constraints of the distributed natured of such a render.
-   * Often, it is not actually of consequence. To allow the @ref manager
-   * to handle these situations correctly, Hosts are required to set
-   * this property to reflect their ability to persist this information.
-   */
-  Retention retention;
 
   /**
    * In many situations, the @ref trait_set of the desired @ref entity
@@ -159,7 +120,6 @@ class OPENASSETIO_CORE_EXPORT Context final {
    * should always be used instead.
    */
   [[nodiscard]] static ContextPtr make(Access access = Access::kUnknown,
-                                       Retention retention = Retention::kTransient,
                                        TraitsDataPtr locale = nullptr,
                                        managerApi::ManagerStateBasePtr managerState = nullptr);
   /**
@@ -177,8 +137,7 @@ class OPENASSETIO_CORE_EXPORT Context final {
   }
 
  private:
-  Context(Access access, Retention retention, TraitsDataPtr locale,
-          managerApi::ManagerStateBasePtr managerState);
+  Context(Access access, TraitsDataPtr locale, managerApi::ManagerStateBasePtr managerState);
 };
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -337,7 +337,7 @@ class OPENASSETIO_CORE_EXPORT Manager {
    *  meaningful state etc... This can be useful when certain UI
    *  elements need to 'take a copy' of a context in its current state
    *  in order to parallelise actions that are part of the same logical
-   *  group, but have different locales, access or retention.
+   *  group, but have different locales or access.
    *
    *  @see @ref createContext
    *  @see @fqref{Context} "Context"
@@ -364,8 +364,7 @@ class OPENASSETIO_CORE_EXPORT Manager {
    *  @warning This only encapsulates the logical identity of the
    *  Context, such that when restored, any API calls made using the
    *  resulting Context will be logically associated with the one
-   *  supplied here. It does not encode the current access, retention
-   *  or locale.
+   *  supplied here. It does not encode the current access or locale.
    *
    *  @see @ref stable_resolution
    */
@@ -385,7 +384,7 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * group of actions as the context supplied to @ref
    * persistenceTokenForContext to generate the token.
    *
-   * @warning The context's access, retention or locale is not
+   * @warning The context's access or locale is not
    * restored by this action.
    *
    * @see @ref stable_resolution
@@ -1216,8 +1215,8 @@ class OPENASSETIO_CORE_EXPORT Manager {
    * glossary_preflight "glossary entry" for details.
    *
    * @note It's vital that the @ref Context is well configured here,
-   * in particular the @fqref{Context.retention}
-   * "Context.retention".
+   * in particular the @fqref{Context.access}
+   * "Context.access".
    *
    * @warning The working @ref entity_reference returned by this
    * method should *always* be used in place of the original

--- a/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
+++ b/src/openassetio-core/include/openassetio/managerApi/ManagerInterface.hpp
@@ -506,7 +506,7 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * @param parentState obj, The new state is to be considered a
    * 'child' of the supplied state. This may be used when creating a
    * child Context for persistence somewhere in a UI, etc... when
-   * further processing may change the access/retention of the
+   * further processing may change the access of the
    * Context. It is expected that the manager will migrate any
    * applicable state components to this child context, for example -
    * a timestamp used for 'vlatest'.
@@ -1237,10 +1237,6 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * who's corresponding @p traitsHints entry holds insufficient or
    * invalid information.
    *
-   * @note it is important for the implementation to pay attention to
-   * @fqref{Context.retention} "Context.retention", as not all hosts
-   * will support the reference changing at this point.
-   *
    * @see @ref register_
    */
   virtual void preflight(const EntityReferences& entityReferences,
@@ -1337,10 +1333,6 @@ class OPENASSETIO_CORE_EXPORT ManagerInterface {
    * @fqref{BatchElementError.ErrorCode} "ErrorCodes"). The callback
    * must be called on the same thread that initiated the call to
    * `register`.
-   *
-   * @note it is important for the implementation to pay attention to
-   * @fqref{Context.retention} "retention", as not all Hosts will
-   * support the reference changing at this point.
    *
    * @see @fqref{TraitsData} "TraitsData"
    * @see @ref preflight

--- a/src/openassetio-core/src/Context.cpp
+++ b/src/openassetio-core/src/Context.cpp
@@ -4,17 +4,13 @@
 
 namespace openassetio {
 inline namespace OPENASSETIO_CORE_ABI_VERSION {
-ContextPtr Context::make(Access access, Retention retention, TraitsDataPtr locale,
+ContextPtr Context::make(Access access, TraitsDataPtr locale,
                          managerApi::ManagerStateBasePtr managerState) {
-  return std::shared_ptr<Context>(
-      new Context(access, retention, std::move(locale), std::move(managerState)));
+  return std::shared_ptr<Context>(new Context(access, std::move(locale), std::move(managerState)));
 }
 
-Context::Context(Access access_, Retention retention_, TraitsDataPtr locale_,
+Context::Context(Access access_, TraitsDataPtr locale_,
                  managerApi::ManagerStateBasePtr managerState_)
-    : access{access_},
-      retention{retention_},
-      locale{std::move(locale_)},
-      managerState{std::move(managerState_)} {}
+    : access{access_}, locale{std::move(locale_)}, managerState{std::move(managerState_)} {}
 }  // namespace OPENASSETIO_CORE_ABI_VERSION
 }  // namespace openassetio

--- a/src/openassetio-core/src/hostApi/Manager.cpp
+++ b/src/openassetio-core/src/hostApi/Manager.cpp
@@ -115,8 +115,8 @@ ContextPtr Manager::createContext() {
 ContextPtr Manager::createChildContext(const ContextPtr &parentContext) {
   // Copy-construct the locale so changes made to the child context don't
   // affect the parent (and visa versa).
-  ContextPtr context = Context::make(parentContext->access, parentContext->retention,
-                                     TraitsData::make(parentContext->locale));
+  ContextPtr context =
+      Context::make(parentContext->access, TraitsData::make(parentContext->locale));
   if (parentContext->managerState) {
     context->managerState =
         managerInterface_->createChildState(parentContext->managerState, hostSession_);

--- a/src/openassetio-core/tests/ContextTest.cpp
+++ b/src/openassetio-core/tests/ContextTest.cpp
@@ -12,7 +12,7 @@ OPENASSETIO_FWD_DECLARE(managerApi, ManagerStateBase)
 using openassetio::Context;
 
 SCENARIO("Context constructor is private") {
-  STATIC_REQUIRE_FALSE(std::is_constructible_v<Context, Context::Access, Context::Retention,
-                                               openassetio::TraitsDataPtr,
-                                               openassetio::managerApi::ManagerStateBasePtr>);
+  STATIC_REQUIRE_FALSE(
+      std::is_constructible_v<Context, Context::Access, openassetio::TraitsDataPtr,
+                              openassetio::managerApi::ManagerStateBasePtr>);
 }

--- a/src/openassetio-python/cmodule/src/ContextBinding.cpp
+++ b/src/openassetio-python/cmodule/src/ContextBinding.cpp
@@ -28,21 +28,11 @@ void registerContext(const py::module& mod) {
 
   context.def_readonly_static("kAccessNames", &Context::kAccessNames);
 
-  py::enum_<Context::Retention>{context, "Retention"}
-      .value("kIgnored", Context::Retention::kIgnored)
-      .value("kTransient", Context::Retention::kTransient)
-      .value("kSession", Context::Retention::kSession)
-      .value("kPermanent", Context::Retention::kPermanent);
-
-  context.def_readonly_static("kRetentionNames", &Context::kRetentionNames);
-
   context
       .def(py::init(RetainCommonPyArgs::forFn<&Context::make>()),
-           py::arg_v("access", Context::Access::kUnknown),
-           py::arg_v("retention", Context::Retention::kTransient),
-           py::arg_v("locale", TraitsDataPtr{}), py::arg_v("managerState", ManagerStateBasePtr{}))
+           py::arg_v("access", Context::Access::kUnknown), py::arg_v("locale", TraitsDataPtr{}),
+           py::arg_v("managerState", ManagerStateBasePtr{}))
       .def_readwrite("access", &Context::access)
-      .def_readwrite("retention", &Context::retention)
       .def_readwrite("locale", &Context::locale)
       .def_property(
           "managerState", [](const Context& self) { return self.managerState; },

--- a/src/openassetio-python/package/openassetio/_core/audit.py
+++ b/src/openassetio-python/package/openassetio/_core/audit.py
@@ -124,7 +124,6 @@ def auditApiCall(group=None, static=False):
     """
 
     def _wrapAuditApiCall(function):
-
         # We deliberately don't wrap the function if its disabled as it
         # a) obfuscates docstrings
         # b) adds unnecessarily to the call stack
@@ -133,7 +132,6 @@ def auditApiCall(group=None, static=False):
 
         @functools.wraps(function)
         def _auditApiCall(*args, **kwargs):
-
             if auditCalls:
                 sharedAuditor = auditor()
 
@@ -189,7 +187,6 @@ def __auditObj(aud, obj):
         # If its a Context, add the context, and its options
         aud.addClass(obj)
         aud.addObj("Context.%s" % obj.access, group="Context Access")
-        aud.addObj("Context.%s" % obj.kRetentionNames[obj.retention], group="Context Retention")
         if obj.locale:
             aud.addClass(obj.locale, group="Locales")
 
@@ -439,7 +436,6 @@ class Auditor(object):
 
     @staticmethod
     def __classFromObj(obj):
-
         # If its an instance method then get self, which will be an instance, or a
         # class in the case of @classmethods
         if hasattr(obj, "im_self"):

--- a/src/openassetio-python/tests/package/hostApi/test_manager.py
+++ b/src/openassetio-python/tests/package/hostApi/test_manager.py
@@ -2905,7 +2905,6 @@ class Test_Manager_createContext:
         context_a = manager.createContext()
 
         assert context_a.access == Context.Access.kUnknown
-        assert context_a.retention == Context.Retention.kTransient
         assert context_a.managerState is state_a
         assert isinstance(context_a.locale, TraitsData)
         assert context_a.locale.traitSet() == set()
@@ -2924,7 +2923,6 @@ class Test_Manager_createChildContext:
         mock_manager_interface.mock.createState.return_value = state_a
         context_a = manager.createContext()
         context_a.access = Context.Access.kWrite
-        context_a.retention = Context.Retention.kSession
         context_a.locale = TraitsData()
         mock_manager_interface.mock.reset_mock()
 
@@ -2936,7 +2934,6 @@ class Test_Manager_createChildContext:
         assert context_b is not context_a
         assert context_b.managerState is state_b
         assert context_b.access == context_a.access
-        assert context_b.retention == context_a.retention
         assert context_b.locale == context_a.locale
         mock_manager_interface.mock.createChildState.assert_called_once_with(
             state_a, a_host_session
@@ -2954,7 +2951,6 @@ class Test_Manager_createChildContext:
         mock_manager_interface.mock.createChildState.return_value = state_a
         context_a = manager.createContext()
         context_a.access = Context.Access.kWrite
-        context_a.retention = Context.Retention.kSession
         context_a.locale = original_locale
 
         context_b = manager.createChildContext(context_a)
@@ -2968,12 +2964,10 @@ class Test_Manager_createChildContext:
     ):
         context_a = Context()
         context_a.access = Context.Access.kWrite
-        context_a.retention = Context.Retention.kSession
         context_a.locale = TraitsData()
         context_b = manager.createChildContext(context_a)
 
         assert context_b.access == context_a.access
-        assert context_b.retention == context_a.retention
         assert context_b.locale == context_b.locale
         mock_manager_interface.mock.createChildState.assert_not_called()
 

--- a/src/openassetio-python/tests/package/test_context.py
+++ b/src/openassetio-python/tests/package/test_context.py
@@ -44,31 +44,11 @@ class Test_Context:
         assert Context.kAccessNames[int(Context.Access.kCreateRelated)] == "createRelated"
         assert Context.kAccessNames[int(Context.Access.kUnknown)] == "unknown"
 
-    def test_retention_constants_are_not_exported(self):
-        with pytest.raises(AttributeError):
-            Context.kIgnored  # pylint: disable=pointless-statement
-
-    def test_retention_constants_are_unique(self):
-        consts = (
-            Context.Retention.kIgnored,
-            Context.Retention.kTransient,
-            Context.Retention.kSession,
-            Context.Retention.kPermanent,
-        )
-        assert len(set(consts)) == len(consts)
-
-    def test_retention_names_indices_match_constants(self):
-        assert Context.kRetentionNames[int(Context.Retention.kIgnored)] == "ignored"
-        assert Context.kRetentionNames[int(Context.Retention.kTransient)] == "transient"
-        assert Context.kRetentionNames[int(Context.Retention.kSession)] == "session"
-        assert Context.kRetentionNames[int(Context.Retention.kPermanent)] == "permanent"
-
 
 class Test_Context_init:
     def test_when_constructed_with_no_args_then_has_default_configuration(self):
         context = Context()
         assert context.access == Context.Access.kUnknown
-        assert context.retention == Context.Retention.kTransient
         assert context.locale is None
         assert context.managerState is None
 
@@ -77,14 +57,12 @@ class Test_Context_init:
             pass
 
         expected_access = Context.Access.kRead
-        expected_retention = Context.Retention.kSession
         expected_locale = TraitsData()
         expected_state = TestState()
 
-        a_context = Context(expected_access, expected_retention, expected_locale, expected_state)
+        a_context = Context(expected_access, expected_locale, expected_state)
 
         assert a_context.access == expected_access
-        assert a_context.retention == expected_retention
         assert a_context.locale is expected_locale
         assert a_context.managerState is expected_state
         assert isinstance(a_context.managerState, TestState)
@@ -108,27 +86,6 @@ class Test_Context_access:
         ):
             a_context.access = expected_access
             assert a_context.access == expected_access
-
-
-class Test_Context_retention:
-    def test_when_set_to_unknown_type_then_raises_ValueError(self, a_context):
-        expected_msg = (
-            r"incompatible function arguments.*\n"
-            r".*arg0: openassetio._openassetio.Context.Retention"
-        )
-
-        with pytest.raises(TypeError, match=expected_msg):
-            a_context.retention = 0
-
-    def test_when_set_to_known_value_then_stores_that_value(self, a_context):
-        for expected_retention in (
-            Context.Retention.kIgnored,
-            Context.Retention.kTransient,
-            Context.Retention.kSession,
-            Context.Retention.kPermanent,
-        ):
-            a_context.retention = expected_retention
-            assert a_context.retention == expected_retention
 
 
 class Test_Context_locale:


### PR DESCRIPTION
#1048
Remove retention enum from context, as its usage is tenuous now we have compositional locales, and relationship methods for stable refs.

## Description

Closes # (issue)

- [ ] I have updated the release notes.
- [ ] I have updated all relevant user documentation.

## Reviewer Notes

<!--- Provide any notes to the reviewer that might help them more easily
      understand the changeset. --->

## Test Instructions

<!--- Provide instructions to the reviewer on how to explicitly test
      these changes. --->
