### PR TITLE
[Lint] Standardize line endings.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force linux style line endings.
+* text=auto eol=lf

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -48,7 +48,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -62,5 +62,5 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
 

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -26,7 +26,7 @@ jobs:
       # This does however mean that when making a release, you must be
       # sure that the build-wheels job on main has completed
       - name: Download wheels from commit ${{ github.sha }}
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v3
         with:
           workflow: build-wheels.yml
           workflow_conclusion: success
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Download wheels from commit ${{ github.sha }}
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v3
         with:
           workflow: build-wheels.yml
           workflow_conclusion: success

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -70,10 +70,6 @@ jobs:
       - name: Test BAL
         run: |
           python -m pip install external/BAL
-          # We can't install BAL's requirements.txt as this includes
-          # openassetio... we really need to sort
-          # https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/72
-          python -m pip install openassetio-mediacreation
           python -m pip install -r external/BAL/tests/requirements.txt
           python -m pytest -v external/BAL/tests
 

--- a/src/openassetio-python/pyproject.toml
+++ b/src/openassetio-python/pyproject.toml
@@ -1,12 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2021-2022 The Foundry Visionmongers Ltd
 
-# https://discourse.cmake.org/t/3-28-segmentation-fault-on-macos-11-runner/9588
-# Revert cmake maximum once cmake is patched.
 [build-system]
 requires = [
     "setuptools>=65.5.0",
-    "cmake>=3.24.1.1, <3.28",
+    "cmake>=3.24.1.1",
     "ninja>=1.10.2.4"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
#1200, explicitly set git behaviour for line endings , ensuring linux style line endings.
We noted in some cases our CI was configured with automatic end of line conversion, which cause some linting problems, especially on windows.

Body Wrap at 72 chars. ################################# which is here!

## Description

Closes # (issue)

- [ ] I have updated the release notes.
- [ ] I have updated all relevant user documentation.

## Reviewer Notes

<!--- Provide any notes to the reviewer that might help them more easily
      understand the changeset. --->

## Test Instructions

<!--- Provide instructions to the reviewer on how to explicitly test
      these changes. --->
