### PR TITLE
[CI] Limit upper bound cmake version

### DIFF
--- a/src/openassetio-python/pyproject.toml
+++ b/src/openassetio-python/pyproject.toml
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2021-2022 The Foundry Visionmongers Ltd
 
+# https://discourse.cmake.org/t/3-28-segmentation-fault-on-macos-11-runner/9588
+# Revert cmake maximum once cmake is patched.
 [build-system]
 requires = [
     "setuptools>=65.5.0",
-    "cmake>=3.24.1.1",
+    "cmake>=3.24.1.1, <3.28",
     "ninja>=1.10.2.4"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Causing CI to fail. This is probably not the best solution, just a test.

## Description

Closes # (issue)

- [ ] I have updated the release notes.
- [ ] I have updated all relevant user documentation.

## Reviewer Notes

<!--- Provide any notes to the reviewer that might help them more easily
      understand the changeset. --->

## Test Instructions

<!--- Provide instructions to the reviewer on how to explicitly test
      these changes. --->
