### PR TITLE
[CI] Add Ayon test integration

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -264,7 +264,7 @@ jobs:
           --header "x-ayon-hostname: phobos"
           --header "x-api-key: ${{ secrets.AYON_API_KEY }}"
           --header "x-as-user: service"
-          --header "x-ayon-version: 1.0.0-rc.2+DEVELOP" http://localhost:5000/api/info
+          --header "x-ayon-version: 1.0.0-rc.2+DEVELOP" http://127.0.0.1:5000/api/info
 
       - name: Run Ayon tests
         run: |

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -259,6 +259,12 @@ jobs:
 
       - name: Run Ayon tests
         run: |
+          curl --header "x-ayon-site-id: oaio-tests"
+          --header "x-ayon-platform: linux"
+          --header "x-ayon-hostname: phobos"
+          --header "x-api-key: ${{ secrets.AYON_API_KEY }}"
+          --header "x-as-user: service"
+          --header "x-ayon-version: 1.0.0-rc.2+DEVELOP" http://localhost:5000/api/info
           cd ${{ github.workspace }}/ynput/ayon-openassetio-manager-plugin
           .poetry/bin/poetry run pytest -v
         env:

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -203,3 +203,71 @@ jobs:
         env:
           CMAKE_PREFIX_PATH: ${{ github.workspace }}/dist
           CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/.conan/conan_paths.cmake
+
+  ayon-integration:
+    name: Ayon resolver on ${{ matrix.config.os }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - os: windows-2019
+          site-packages: Lib/site-packages
+        - os: ubuntu-20.04
+          site-packages: lib/python3.9/site-packages
+        - os: macos-11
+          # MacOS toolchain doesn't search /usr/local by default:
+          # https://gitlab.kitware.com/cmake/cmake/-/issues/19120
+          # The CMake FindPython module's Python::Python target (used in
+          # OpenAssetIO-Test-CMake) transitively adds linker flags to
+          # system libs, which fail due to this issue.
+          preamble: export LDFLAGS="-L/usr/local/lib"
+          site-packages: lib/python3.9/site-packages
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bootstrap
+        uses: ./.github/bootstrap_platform
+
+      - name: Build OpenAssetIO (setup.py)
+        run: |
+          ${{ matrix.config.preamble }}
+          python -m pip install src/openassetio-python
+        env:
+          CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/.conan/conan_paths.cmake
+
+      - name: Checkout Ayon
+        uses: actions/checkout@v4
+        with:
+          repository: ynput/ayon-openassetio-manager-plugin
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: ${{ github.workspace }}/ynput/ayon-openassetio-manager-plugin
+
+      - name: Install and configure Poetry
+        run: |
+          cd ${{ github.workspace }}/ynput/ayon-openassetio-manager-plugin
+          mkdir -p ${{ github.workspace }}/ynput/ayon-openassetio-manager-plugin/.poetry
+          export POETRY_HOME="${{ github.workspace }}/ynput/ayon-openassetio-manager-plugin/.poetry"
+          curl -sSL https://install.python-poetry.org/ | python -
+          "${POETRY_HOME}/bin/poetry" config virtualenvs.in-project true --local
+          "${POETRY_HOME}/bin/poetry" config virtualenvs.create true --local
+          "${POETRY_HOME}/bin/poetry" install --no-root $poetry_verbosity --ansi
+
+      - name: Run Ayon tests
+        run: |
+          cd ${{ github.workspace }}/ynput/ayon-openassetio-manager-plugin
+          .poetry/bin/poetry run pytest -v
+        env:
+          AYON_SERVER_URL: https://openassetio.ayon.dev
+          AYON_API_KEY: ${{ secrets.AYON_API_KEY }}
+          OPENASSETIO_PLUGIN_PATH: ${{ github.workspace }}/ynput/ayon-openassetio-manager-plugin/AyonOpenAssetIOManager
+          OPENASSETIO_DEFAULT_CONFIG: ${{ github.workspace }}/ynput/ayon-openassetio-manager-plugin/pyproject.toml
+
+
+
+
+

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -257,14 +257,17 @@ jobs:
           "${POETRY_HOME}/bin/poetry" config virtualenvs.create true --local
           "${POETRY_HOME}/bin/poetry" install --no-root $poetry_verbosity --ansi
 
-      - name: Run Ayon tests
-        run: |
+      - name: Configure Ayon Site
+        run: >
           curl --header "x-ayon-site-id: oaio-tests"
           --header "x-ayon-platform: linux"
           --header "x-ayon-hostname: phobos"
           --header "x-api-key: ${{ secrets.AYON_API_KEY }}"
           --header "x-as-user: service"
           --header "x-ayon-version: 1.0.0-rc.2+DEVELOP" http://localhost:5000/api/info
+
+      - name: Run Ayon tests
+        run: |
           cd ${{ github.workspace }}/ynput/ayon-openassetio-manager-plugin
           .poetry/bin/poetry run pytest -v
         env:

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -243,7 +243,7 @@ jobs:
       - name: Checkout Ayon
         uses: actions/checkout@v4
         with:
-          repository: ynput/ayon-openassetio-manager-plugin
+          repository: elliotcmorris/ayon-openassetio-manager-plugin
           token: ${{ secrets.GITHUB_TOKEN }}
           path: ${{ github.workspace }}/ynput/ayon-openassetio-manager-plugin
 


### PR DESCRIPTION
Ayon e2e integration #1219

Adds ayon tests to our integrations.yml file. Pulls from the ayon repo and configures the environment using poetry, as instructed by ayon.

## Description

Closes # (issue)

- [ ] I have updated the release notes.
- [ ] I have updated all relevant user documentation.

## Reviewer Notes

<!--- Provide any notes to the reviewer that might help them more easily
      understand the changeset. --->

## Test Instructions

<!--- Provide instructions to the reviewer on how to explicitly test
      these changes. --->
