### PR TITLE
[Core] Add GetWithRelationship(s) convenience signatures

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,6 +27,14 @@ v1.0.0-beta.x.y
   logger.
   [#1014](https://github.com/OpenAssetIO/OpenAssetIO/issues/1014)
 
+### Improvements
+
+- Added `getRelationship(s)` overloads for convenience, providing
+  alternatives to the core callback-based workflow. Includes a more
+  direct method for resolving relationships for single entity
+  references, or single relationships, as well exception vs. result
+  object workflows.
+  [#973](https://github.com/OpenAssetIO/OpenAssetIO/issues/973)
 
 v1.0.0-beta.2.1
 ---------------

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,11 @@ v1.0.0-beta.x.y
   a `CppPluginSystemManagerPlugin` object.
   [#1115](https://github.com/OpenAssetIO/OpenAssetIO/issues/1115)
 
+- `openassetio.test.manager`, notably used for Api Compliance tests,
+  updated to automatically load C++ plugins if a python plugin of the
+  requested identifier cannot be found.
+  [#1294](https://github.com/OpenAssetIO/OpenAssetIO/issues/1294)
+
 - Added `LoggerInterface.isSeverityLogged` to allow users to
   short-circuit log message construction if the logger indicates the
   intended severity will be filtered. Updated `SeverityFilter` to use

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -1481,6 +1481,35 @@ class OPENASSETIO_CORE_EXPORT Manager final {
                            const BatchElementErrorCallback& errorCallback,
                            const trait::TraitSet& resultTraitSet = {});
 
+  // Singular except
+  EntityReferencePagerPtr getWithRelationship(
+      const EntityReference& entityReference, const trait::TraitsDataPtr& relationshipTraitsData,
+      size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+      const trait::TraitSet& resultTraitSet,
+      const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
+
+  // Singular variant
+  std::variant<errors::BatchElementError, EntityReferencePagerPtr> getWithRelationship(
+      const EntityReference& entityReference, const trait::TraitsDataPtr& relationshipTraitsData,
+      size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+      const trait::TraitSet& resultTraitSet,
+      const BatchElementErrorPolicyTag::Variant& errorPolicyTag);
+
+  // Multi except
+  std::vector<EntityReferencePagerPtr> getWithRelationship(
+      const EntityReferences& entityReferences, const trait::TraitsDataPtr& relationshipTraitsData,
+      size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+      const trait::TraitSet& resultTraitSet,
+      const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
+
+  // Multi variant
+  std::vector<std::variant<errors::BatchElementError, EntityReferencePagerPtr>>
+  getWithRelationship(const EntityReferences& entityReferences,
+                      const trait::TraitsDataPtr& relationshipTraitsData, size_t pageSize,
+                      access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+                      const trait::TraitSet& resultTraitSet,
+                      const BatchElementErrorPolicyTag::Variant& errorPolicyTag);
+
   /**
    * Queries entity references that are related to the input reference
    * by the relationships defined by a set of traits and their
@@ -1552,6 +1581,36 @@ class OPENASSETIO_CORE_EXPORT Manager final {
                             const RelationshipQuerySuccessCallback& successCallback,
                             const BatchElementErrorCallback& errorCallback,
                             const trait::TraitSet& resultTraitSet = {});
+
+  // Singular except
+  EntityReferencePagerPtr getWithRelationships(
+      const EntityReference& entityReference, const trait::TraitsDataPtr& relationshipTraitsData,
+      size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+      const trait::TraitSet& resultTraitSet,
+      const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
+
+  // Singular variant
+  std::variant<errors::BatchElementError, EntityReferencePagerPtr> getWithRelationships(
+      const EntityReference& entityReference, const trait::TraitsDataPtr& relationshipTraitsData,
+      size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+      const trait::TraitSet& resultTraitSet,
+      const BatchElementErrorPolicyTag::Variant& errorPolicyTag);
+
+  // Multi except
+  std::vector<EntityReferencePagerPtr> getWithRelationships(
+      const EntityReference& entityReference, const trait::TraitsDatas& relationshipTraitsDatas,
+      size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+      const trait::TraitSet& resultTraitSet,
+      const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
+
+  // Multi variant
+  std::vector<std::variant<errors::BatchElementError, EntityReferencePagerPtr>>
+  getWithRelationships(const EntityReference& entityReference,
+                       const trait::TraitsDatas& relationshipTraitsDatas, size_t pageSize,
+                       access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+                       const trait::TraitSet& resultTraitSet,
+                       const BatchElementErrorPolicyTag::Variant& errorPolicyTag);
+
   /// @}
 
   /**

--- a/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
+++ b/src/openassetio-core/include/openassetio/hostApi/Manager.hpp
@@ -1421,6 +1421,9 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * This is an essential function in this API - as it is widely used
    * to query other entities or organisational structure.
    *
+   * When calling this method, you can expect to receive one result
+   * per @ref entity_reference provided.
+   *
    * @note Consult the documentation for the relevant relationship
    * traits to determine if the order of entities in the inner lists
    * of matching references is considered meaningful.
@@ -1481,28 +1484,254 @@ class OPENASSETIO_CORE_EXPORT Manager final {
                            const BatchElementErrorCallback& errorCallback,
                            const trait::TraitSet& resultTraitSet = {});
 
-  // Singular except
+  /**
+   * Query an entity reference that are related to the input
+   * reference by the relationship defined by a set of traits and
+   * their properties.
+   *
+   * See documentation for the <!--
+   * --> @ref getWithRelationship(const EntityReferences&, <!--
+   * --> const trait::TraitsDataPtr&, size_t, <!--
+   * --> access::RelationsAccess, const ContextConstPtr&, <!--
+   * --> const RelationshipQuerySuccessCallback&, <!--
+   * --> const BatchElementErrorCallback& errorCallback, <!--
+   * --> const trait::TraitSet&)
+   * "callback variation" for more details on resolution behaviour.
+   *
+   * Any errors that occur during resolution will be immediately thrown
+   * as an exception, either from the @ref manager plugin (for errors
+   * not specific to the entity reference) or as a
+   * @fqref{errors.BatchElementException}
+   * "BatchElementException"-derived error.
+   *
+   * @param entityReference An @ref entity_reference to query
+   * the specified relationship for.
+   *
+   * @param relationshipTraitsData The traits of the relationship to
+   * query.
+   *
+   * @param pageSize The size of each page of data. The page size is
+   * fixed for the lifetime of pager object given to the @p
+   * successCallback. Must be greater than zero.
+   *
+   * @param relationsAccess The intended usage of the returned
+   * references.
+   *
+   * @param context The calling context.
+   *
+   * @param resultTraitSet A hint as to what traits the returned
+   * entities should have.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Exception.
+   *
+   * @return @ref EntityReferencePager pointer. Pages over
+   * an unbounded set of entityReferences related to the input
+   * entityReference.
+   *
+   * @throws errors.InputValidationException if @p pageSize is zero.
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kRelationshipQueries.
+   *
+   * @see @ref Capability.kRelationshipQueries
+   */
   EntityReferencePagerPtr getWithRelationship(
       const EntityReference& entityReference, const trait::TraitsDataPtr& relationshipTraitsData,
       size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr& context,
       const trait::TraitSet& resultTraitSet,
       const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
 
-  // Singular variant
+  /**
+   * Query an entity reference that are related to the input
+   * reference by the relationship defined by a set of traits and
+   * their properties.
+   *
+   * See documentation for the <!--
+   * --> @ref getWithRelationship(const EntityReferences&, <!--
+   * --> const trait::TraitsDataPtr&, size_t, <!--
+   * --> access::RelationsAccess, const ContextConstPtr&, <!--
+   * --> const RelationshipQuerySuccessCallback&, <!--
+   * --> const BatchElementErrorCallback& errorCallback, <!--
+   * --> const trait::TraitSet&)
+   * "callback variation" for more details on resolution behaviour.
+   *
+   * For successful references, the corresponding element of the result
+   * is populated with the available data for the requested set of
+   * traits.
+   *
+   * Otherwise, the corresponding element of the result is populated
+   * with an error object detailing the reason for the failure to
+   * fetch the related entities for that particular relationship.
+   *
+   * Errors that are not specific to an entity will be thrown as an
+   * exception, failing the whole batch.
+   *
+   * @param entityReference An @ref entity_reference to query
+   * the specified relationship for.
+   *
+   * @param relationshipTraitsData The traits of the relationship to
+   * query.
+   *
+   * @param pageSize The size of each page of data. The page size is
+   * fixed for the lifetime of pager object given to the @p
+   * successCallback. Must be greater than zero.
+   *
+   * @param relationsAccess The intended usage of the returned
+   * references.
+   *
+   * @param context The calling context.
+   *
+   * @param resultTraitSet A hint as to what traits the returned
+   * entities should have.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Variant.
+   *
+   * @return Object containing either the EntityReferencePager pointer,
+   * which pages over an unbounded set of entityReferences related to
+   * the input entityReference, or an error.
+   *
+   * @throws errors.InputValidationException if @p pageSize is zero.
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kRelationshipQueries.
+   *
+   * @see @ref Capability.kRelationshipQueries
+   */
   std::variant<errors::BatchElementError, EntityReferencePagerPtr> getWithRelationship(
       const EntityReference& entityReference, const trait::TraitsDataPtr& relationshipTraitsData,
       size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr& context,
       const trait::TraitSet& resultTraitSet,
       const BatchElementErrorPolicyTag::Variant& errorPolicyTag);
 
-  // Multi except
+  /**
+   * Query entity references that are related to the input
+   * references by the relationship defined by a set of traits and
+   * their properties.
+   *
+   * See documentation for the <!--
+   * --> @ref getWithRelationship(const EntityReferences&, <!--
+   * --> const trait::TraitsDataPtr&, size_t, <!--
+   * --> access::RelationsAccess, const ContextConstPtr&, <!--
+   * --> const RelationshipQuerySuccessCallback&, <!--
+   * --> const BatchElementErrorCallback& errorCallback, <!--
+   * --> const trait::TraitSet&)
+   * "callback variation" for more details on resolution behaviour.
+   *
+   * Any errors that occur during resolution will be immediately thrown
+   * as an exception, either from the @ref manager plugin (for errors
+   * not specific to the entity reference) or as a
+   * @fqref{errors.BatchElementException}
+   * "BatchElementException"-derived error.
+   *
+   * @param entityReferences A list of @ref entity_reference to query
+   * the specified relationship for.
+   *
+   * @param relationshipTraitsData The traits of the relationship to
+   * query.
+   *
+   * @param pageSize The size of each page of data. The page size is
+   * fixed for the lifetime of pager object given to the @p
+   * successCallback. Must be greater than zero.
+   *
+   * @param relationsAccess The intended usage of the returned
+   * references.
+   *
+   * @param context The calling context.
+   *
+   * @param resultTraitSet A hint as to what traits the returned
+   * entities should have.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Exception.
+   *
+   * @return List of @ref EntityReferencePager pointers. These page over
+   * unbounded sets of entityReferences related to the input
+   * entityReferences.
+   *
+   * @throws errors.InputValidationException if @p pageSize is zero.
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kRelationshipQueries.
+   *
+   * @see @ref Capability.kRelationshipQueries
+   */
   std::vector<EntityReferencePagerPtr> getWithRelationship(
       const EntityReferences& entityReferences, const trait::TraitsDataPtr& relationshipTraitsData,
       size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr& context,
       const trait::TraitSet& resultTraitSet,
       const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
 
-  // Multi variant
+  /**
+   * Query entity references that are related to the input
+   * references by the relationship defined by a set of traits and
+   * their properties.
+   *
+   * See documentation for the <!--
+   * --> @ref getWithRelationship(const EntityReferences&, <!--
+   * --> const trait::TraitsDataPtr&, size_t, <!--
+   * --> access::RelationsAccess, const ContextConstPtr&, <!--
+   * --> const RelationshipQuerySuccessCallback&, <!--
+   * --> const BatchElementErrorCallback& errorCallback, <!--
+   * --> const trait::TraitSet&)
+   * "callback variation" for more details on resolution behaviour.
+   *
+   * For successful references, the corresponding element of the result
+   * is populated with the available data for the requested set of
+   * traits.
+   *
+   * Otherwise, the corresponding element of the result is populated
+   * with an error object detailing the reason for the failure to
+   * fetch the related entities for that particular relationship.
+   *
+   * Errors that are not specific to an entity will be thrown as an
+   * exception, failing the whole batch.
+   *
+   * @param entityReferences A list of @ref entity_reference to query
+   * the specified relationship for.
+   *
+   * @param relationshipTraitsData The traits of the relationship to
+   * query.
+   *
+   * @param pageSize The size of each page of data. The page size is
+   * fixed for the lifetime of pager object given to the @p
+   * successCallback. Must be greater than zero.
+   *
+   * @param relationsAccess The intended usage of the returned
+   * references.
+   *
+   * @param context The calling context.
+   *
+   * @param resultTraitSet A hint as to what traits the returned
+   * entities should have.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Variant.
+   *
+   * @return List of objects, each containing either the
+   * EntityReferencePager pointer, which pages over an unbounded set of
+   * entityReferences related to the input entityReference, or an error.
+   *
+   * @throws errors.InputValidationException if @p pageSize is zero.
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kRelationshipQueries.
+   *
+   * @see @ref Capability.kRelationshipQueries
+   */
   std::vector<std::variant<errors::BatchElementError, EntityReferencePagerPtr>>
   getWithRelationship(const EntityReferences& entityReferences,
                       const trait::TraitsDataPtr& relationshipTraitsData, size_t pageSize,
@@ -1521,6 +1750,9 @@ class OPENASSETIO_CORE_EXPORT Manager final {
    * @note Consult the documentation for the relevant relationship
    * traits to determine if the order of entities in the inner lists of
    * matching references is considered meaningful.
+   *
+   * When calling this method, you can expect to receive one result
+   * per relationship provided in @p relationshipTraitsDatas.
    *
    * If any relationship definition is unknown, then an empty list will
    * be returned for that relationship, and no errors will be raised.
@@ -1582,28 +1814,254 @@ class OPENASSETIO_CORE_EXPORT Manager final {
                             const BatchElementErrorCallback& errorCallback,
                             const trait::TraitSet& resultTraitSet = {});
 
-  // Singular except
+  /**
+   * Query entity references that are related to the input
+   * references by the relationship defined by a set of traits and
+   * their properties.
+   *
+   * See documentation for the <!--
+   * --> @ref getWithRelationships(const EntityReference&, <!--
+   * --> const trait::TraitsDatas&, size_t, <!--
+   * --> access::RelationsAccess, const ContextConstPtr&, <!--
+   * --> const RelationshipQuerySuccessCallback&, <!--
+   * --> const BatchElementErrorCallback& errorCallback, <!--
+   * --> const trait::TraitSet&)
+   * "callback variation" for more details on resolution behaviour.
+   *
+   * Any errors that occur during resolution will be immediately thrown
+   * as an exception, either from the @ref manager plugin (for errors
+   * not specific to the entity reference) or as a
+   * @fqref{errors.BatchElementException}
+   * "BatchElementException"-derived error.
+   *
+   * @param entityReference The @ref entity_reference to query the
+   * specified relationships for.
+   *
+   * @param relationshipTraitsData The traits of the relationship to
+   * query.
+   *
+   * @param pageSize The size of each page of data. The page size is
+   * fixed for the lifetime of pager object given to the @p
+   * successCallback. Must be greater than zero.
+   *
+   * @param relationsAccess The intended usage of the returned
+   * references.
+   *
+   * @param context The calling context.
+   *
+   * @param resultTraitSet A hint as to what traits the returned
+   * entities should have.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Exception.
+   *
+   * @return @ref EntityReferencePager pointer. Pages over
+   * an unbounded set of entityReferences related to the input
+   * entityReference.
+   *
+   * @throws errors.InputValidationException if @p pageSize is zero.
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kRelationshipQueries.
+   *
+   * @see @ref Capability.kRelationshipQueries
+   */
   EntityReferencePagerPtr getWithRelationships(
       const EntityReference& entityReference, const trait::TraitsDataPtr& relationshipTraitsData,
       size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr& context,
       const trait::TraitSet& resultTraitSet,
       const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
 
-  // Singular variant
+  /**
+   * Query entity references that are related to the input
+   * references by the relationship defined by a set of traits and
+   * their properties.
+   *
+   * See documentation for the <!--
+   * --> @ref getWithRelationships(const EntityReference&, <!--
+   * --> const trait::TraitsDatas&, size_t, <!--
+   * --> access::RelationsAccess, const ContextConstPtr&, <!--
+   * --> const RelationshipQuerySuccessCallback&, <!--
+   * --> const BatchElementErrorCallback& errorCallback, <!--
+   * --> const trait::TraitSet&)
+   * "callback variation" for more details on resolution behaviour.
+   *
+   * For successful references, the corresponding element of the result
+   * is populated with the available data for the requested set of
+   * traits.
+   *
+   * Otherwise, the corresponding element of the result is populated
+   * with an error object detailing the reason for the failure to
+   * fetch the related entities for that particular relationship.
+   *
+   * Errors that are not specific to an entity will be thrown as an
+   * exception, failing the whole batch.
+   *
+   * @param entityReference The @ref entity_reference to query the
+   * specified relationships for.
+   *
+   * @param relationshipTraitsData The traits of the relationship to
+   * query.
+   *
+   * @param pageSize The size of each page of data. The page size is
+   * fixed for the lifetime of pager object given to the @p
+   * successCallback. Must be greater than zero.
+   *
+   * @param relationsAccess The intended usage of the returned
+   * references.
+   *
+   * @param context The calling context.
+   *
+   * @param resultTraitSet A hint as to what traits the returned
+   * entities should have.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Variant.
+   *
+   * @return Object containing either the EntityReferencePager pointer,
+   * which pages over an unbounded set of entityReferences related to
+   * the input entityReference, or an error.
+   *
+   * @throws errors.InputValidationException if @p pageSize is zero.
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kRelationshipQueries.
+   *
+   * @see @ref Capability.kRelationshipQueries
+   */
   std::variant<errors::BatchElementError, EntityReferencePagerPtr> getWithRelationships(
       const EntityReference& entityReference, const trait::TraitsDataPtr& relationshipTraitsData,
       size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr& context,
       const trait::TraitSet& resultTraitSet,
       const BatchElementErrorPolicyTag::Variant& errorPolicyTag);
 
-  // Multi except
+  /**
+   * Query entity references that are related to the input
+   * references by the relationship defined by a set of traits and
+   * their properties.
+   *
+   * See documentation for the <!--
+   * --> @ref getWithRelationships(const EntityReference&, <!--
+   * --> const trait::TraitsDatas&, size_t, <!--
+   * --> access::RelationsAccess, const ContextConstPtr&, <!--
+   * --> const RelationshipQuerySuccessCallback&, <!--
+   * --> const BatchElementErrorCallback& errorCallback, <!--
+   * --> const trait::TraitSet&)
+   * "callback variation" for more details on resolution behaviour.
+   *
+   * Any errors that occur during resolution will be immediately thrown
+   * as an exception, either from the @ref manager plugin (for errors
+   * not specific to the entity reference) or as a
+   * @fqref{errors.BatchElementException}
+   * "BatchElementException"-derived error.
+   *
+   * @param entityReference The @ref entity_reference to query the
+   * specified relationships for.
+   *
+   * @param relationshipTraitsDatas The traits of the relationships to
+   * query.
+   *
+   * @param pageSize The size of each page of data. The page size is
+   * fixed for the lifetime of pager object given to the @p
+   * successCallback. Must be greater than zero.
+   *
+   * @param relationsAccess The intended usage of the returned
+   * references.
+   *
+   * @param context The calling context.
+   *
+   * @param resultTraitSet A hint as to what traits the returned
+   * entities should have.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Exception.
+   *
+   * @return List of @ref EntityReferencePager pointers. These page over
+   * unbounded sets of entityReferences related to the input
+   * entityReference.
+   *
+   * @throws errors.InputValidationException if @p pageSize is zero.
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kRelationshipQueries.
+   *
+   * @see @ref Capability.kRelationshipQueries
+   */
   std::vector<EntityReferencePagerPtr> getWithRelationships(
       const EntityReference& entityReference, const trait::TraitsDatas& relationshipTraitsDatas,
       size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr& context,
       const trait::TraitSet& resultTraitSet,
       const BatchElementErrorPolicyTag::Exception& errorPolicyTag = {});
 
-  // Multi variant
+  /**
+   * Query entity references that are related to the input
+   * references by the relationship defined by a set of traits and
+   * their properties.
+   *
+   * See documentation for the <!--
+   * --> @ref getWithRelationships(const EntityReference&, <!--
+   * --> const trait::TraitsDatas&, size_t, <!--
+   * --> access::RelationsAccess, const ContextConstPtr&, <!--
+   * --> const RelationshipQuerySuccessCallback&, <!--
+   * --> const BatchElementErrorCallback& errorCallback, <!--
+   * --> const trait::TraitSet&)
+   * "callback variation" for more details on resolution behaviour.
+   *
+   * For successful references, the corresponding element of the result
+   * is populated with the available data for the requested set of
+   * traits.
+   *
+   * Otherwise, the corresponding element of the result is populated
+   * with an error object detailing the reason for the failure to
+   * fetch the related entities for that particular relationship.
+   *
+   * Errors that are not specific to an entity will be thrown as an
+   * exception, failing the whole batch.
+   *
+   * @param entityReference The @ref entity_reference to query the
+   * specified relationships for.
+   *
+   * @param relationshipTraitsDatas The traits of the relationships to
+   * query.
+   *
+   * @param pageSize The size of each page of data. The page size is
+   * fixed for the lifetime of pager object given to the @p
+   * successCallback. Must be greater than zero.
+   *
+   * @param relationsAccess The intended usage of the returned
+   * references.
+   *
+   * @param context The calling context.
+   *
+   * @param resultTraitSet A hint as to what traits the returned
+   * entities should have.
+   *
+   * @param errorPolicyTag  Parameter for selecting the appropriate
+   * overload (tagged dispatch idiom). See @ref
+   * BatchElementErrorPolicyTag::Variant.
+   *
+   * @return List of objects, each containing either the
+   * EntityReferencePager pointer, which pages over an unbounded set of
+   * entityReferences related to the input entityReference, or an error.
+   *
+   * @throws errors.InputValidationException if @p pageSize is zero.
+   *
+   * @throws errors.NotImplementedException Thrown when this method is
+   * not implemented by the manager. Check that this method is
+   * implemented before use by calling @ref hasCapability with @ref
+   * Capability.kRelationshipQueries.
+   *
+   * @see @ref Capability.kRelationshipQueries
+   */
   std::vector<std::variant<errors::BatchElementError, EntityReferencePagerPtr>>
   getWithRelationships(const EntityReference& entityReference,
                        const trait::TraitsDatas& relationshipTraitsDatas, size_t pageSize,

--- a/src/openassetio-core/src/hostApi/ManagerConveniences.cpp
+++ b/src/openassetio-core/src/hostApi/ManagerConveniences.cpp
@@ -19,6 +19,10 @@ namespace hostApi {
 // alternate, often friendlier signatures wrapping the core batch-first
 // callback-based member functions found in `Manager.cpp`
 
+/******************************************
+ * entityTraits
+ ******************************************/
+
 // Singular Except
 trait::TraitSet hostApi::Manager::entityTraits(
     const EntityReference &entityReference, const access::EntityTraitsAccess entityTraitsAccess,
@@ -102,6 +106,10 @@ hostApi::Manager::entityTraits(
   return results;
 }
 
+/******************************************
+ * resolve
+ ******************************************/
+
 // Singular Except
 trait::TraitsDataPtr hostApi::Manager::resolve(
     const EntityReference &entityReference, const trait::TraitSet &traitSet,
@@ -184,6 +192,10 @@ hostApi::Manager::resolve(
   return resolveResult;
 }
 
+/******************************************
+ * preflight
+ ******************************************/
+
 EntityReference Manager::preflight(
     const EntityReference &entityReference, const trait::TraitsDataPtr &traitsHint,
     const access::PublishingAccess publishingAccess, const ContextConstPtr &context,
@@ -261,6 +273,10 @@ std::vector<std::variant<errors::BatchElementError, EntityReference>> Manager::p
 
   return results;
 }
+
+/******************************************
+ * register_
+ ******************************************/
 
 // Singular Except
 EntityReference hostApi::Manager::register_(
@@ -340,6 +356,193 @@ std::vector<std::variant<errors::BatchElementError, EntityReference>> hostApi::M
       [&result](std::size_t index, errors::BatchElementError error) {
         result[index] = std::move(error);
       });
+
+  return result;
+}
+
+/******************************************
+ * getWithRelationship
+ ******************************************/
+
+// Singular Except
+EntityReferencePagerPtr hostApi::Manager::getWithRelationship(
+    const EntityReference &entityReference, const trait::TraitsDataPtr &relationshipTraitsData,
+    size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr &context,
+    const trait::TraitSet &resultTraitSet,
+    [[maybe_unused]] const BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
+  EntityReferencePagerPtr result = nullptr;
+  getWithRelationship(
+      {entityReference}, relationshipTraitsData, pageSize, relationsAccess, context,
+      [&result]([[maybe_unused]] std::size_t index, EntityReferencePagerPtr pager) {
+        result = std::move(pager);
+      },
+      [&entityReference, relationsAccess](std::size_t index, errors::BatchElementError error) {
+        auto msg = errors::createBatchElementExceptionMessage(
+            error, index, entityReference, static_cast<internal::access::Access>(relationsAccess));
+        throw errors::BatchElementException(index, std::move(error), msg);
+      },
+      resultTraitSet);
+
+  return result;
+}
+
+// Singular Variant
+std::variant<errors::BatchElementError, EntityReferencePagerPtr>
+hostApi::Manager::getWithRelationship(
+    const EntityReference &entityReference, const trait::TraitsDataPtr &relationshipTraitsData,
+    size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr &context,
+    const trait::TraitSet &resultTraitSet,
+    [[maybe_unused]] const BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
+  std::variant<errors::BatchElementError, EntityReferencePagerPtr> result;
+  getWithRelationship(
+      {entityReference}, relationshipTraitsData, pageSize, relationsAccess, context,
+      [&result]([[maybe_unused]] std::size_t index, EntityReferencePagerPtr pager) {
+        result = std::move(pager);
+      },
+      [&result]([[maybe_unused]] std::size_t index, errors::BatchElementError error) {
+        result = std::move(error);
+      },
+      resultTraitSet);
+
+  return result;
+}
+
+// Multi Except
+std::vector<EntityReferencePagerPtr> hostApi::Manager::getWithRelationship(
+    const EntityReferences &entityReferences, const trait::TraitsDataPtr &relationshipTraitsData,
+    size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr &context,
+    const trait::TraitSet &resultTraitSet,
+    [[maybe_unused]] const BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
+  std::vector<EntityReferencePagerPtr> result;
+  result.resize(entityReferences.size());
+
+  getWithRelationship(
+      entityReferences, relationshipTraitsData, pageSize, relationsAccess, context,
+      [&result](std::size_t index, EntityReferencePagerPtr pager) {
+        result[index] = std::move(pager);
+      },
+      [&entityReferences, relationsAccess](std::size_t index, errors::BatchElementError error) {
+        auto msg = errors::createBatchElementExceptionMessage(
+            error, index, entityReferences[index],
+            static_cast<internal::access::Access>(relationsAccess));
+        throw errors::BatchElementException(index, std::move(error), msg);
+      },
+      resultTraitSet);
+
+  return result;
+}
+
+// Multi Variant
+std::vector<std::variant<errors::BatchElementError, EntityReferencePagerPtr>>
+hostApi::Manager::getWithRelationship(
+    const EntityReferences &entityReferences, const trait::TraitsDataPtr &relationshipTraitsData,
+    size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr &context,
+    const trait::TraitSet &resultTraitSet,
+    [[maybe_unused]] const BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
+  std::vector<std::variant<errors::BatchElementError, EntityReferencePagerPtr>> result;
+  result.resize(entityReferences.size(), nullptr);
+
+  getWithRelationship(
+      entityReferences, relationshipTraitsData, pageSize, relationsAccess, context,
+      [&result](std::size_t index, EntityReferencePagerPtr pager) {
+        result[index] = std::move(pager);
+      },
+      [&result](std::size_t index, errors::BatchElementError error) {
+        result[index] = std::move(error);
+      },
+      resultTraitSet);
+
+  return result;
+}
+
+/******************************************
+ * getWithRelationships
+ ******************************************/
+
+// Singular except
+EntityReferencePagerPtr hostApi::Manager::getWithRelationships(
+    const EntityReference &entityReference, const trait::TraitsDataPtr &relationshipTraitsData,
+    size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr &context,
+    const trait::TraitSet &resultTraitSet,
+    [[maybe_unused]] const BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
+  EntityReferencePagerPtr result = nullptr;
+  getWithRelationships(
+      entityReference, {relationshipTraitsData}, pageSize, relationsAccess, context,
+      [&result]([[maybe_unused]] std::size_t index, EntityReferencePagerPtr pager) {
+        result = std::move(pager);
+      },
+      [&entityReference, relationsAccess](std::size_t index, errors::BatchElementError error) {
+        auto msg = errors::createBatchElementExceptionMessage(
+            error, index, entityReference, static_cast<internal::access::Access>(relationsAccess));
+        throw errors::BatchElementException(index, std::move(error), msg);
+      },
+      resultTraitSet);
+
+  return result;
+}
+
+// Singular variant
+std::variant<errors::BatchElementError, EntityReferencePagerPtr>
+hostApi::Manager::getWithRelationships(
+    const EntityReference &entityReference, const trait::TraitsDataPtr &relationshipTraitsData,
+    size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr &context,
+    const trait::TraitSet &resultTraitSet,
+    [[maybe_unused]] const BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
+  std::variant<errors::BatchElementError, EntityReferencePagerPtr> result;
+  getWithRelationships(
+      entityReference, {relationshipTraitsData}, pageSize, relationsAccess, context,
+      [&result]([[maybe_unused]] std::size_t index, EntityReferencePagerPtr pager) {
+        result = std::move(pager);
+      },
+      [&result]([[maybe_unused]] std::size_t index, errors::BatchElementError error) {
+        result = std::move(error);
+      },
+      resultTraitSet);
+
+  return result;
+}
+
+// Multi Except
+std::vector<EntityReferencePagerPtr> hostApi::Manager::getWithRelationships(
+    const EntityReference &entityReference, const trait::TraitsDatas &relationshipTraitsDatas,
+    size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr &context,
+    const trait::TraitSet &resultTraitSet,
+    [[maybe_unused]] const BatchElementErrorPolicyTag::Exception &errorPolicyTag) {
+  std::vector<EntityReferencePagerPtr> result;
+  result.resize(relationshipTraitsDatas.size(), nullptr);
+  getWithRelationships(
+      entityReference, relationshipTraitsDatas, pageSize, relationsAccess, context,
+      [&result](std::size_t index, EntityReferencePagerPtr pager) {
+        result[index] = std::move(pager);
+      },
+      [&entityReference, relationsAccess](std::size_t index, errors::BatchElementError error) {
+        auto msg = errors::createBatchElementExceptionMessage(
+            error, index, entityReference, static_cast<internal::access::Access>(relationsAccess));
+        throw errors::BatchElementException(index, std::move(error), msg);
+      },
+      resultTraitSet);
+
+  return result;
+}
+
+// Multi Variant
+std::vector<std::variant<errors::BatchElementError, EntityReferencePagerPtr>>
+hostApi::Manager::getWithRelationships(
+    const EntityReference &entityReference, const trait::TraitsDatas &relationshipTraitsDatas,
+    size_t pageSize, access::RelationsAccess relationsAccess, const ContextConstPtr &context,
+    const trait::TraitSet &resultTraitSet,
+    [[maybe_unused]] const BatchElementErrorPolicyTag::Variant &errorPolicyTag) {
+  std::vector<std::variant<errors::BatchElementError, EntityReferencePagerPtr>> result;
+  result.resize(relationshipTraitsDatas.size());
+  getWithRelationships(
+      entityReference, relationshipTraitsDatas, pageSize, relationsAccess, context,
+      [&result](std::size_t index, EntityReferencePagerPtr pager) {
+        result[index] = std::move(pager);
+      },
+      [&result](std::size_t index, errors::BatchElementError error) {
+        result[index] = std::move(error);
+      },
+      resultTraitSet);
 
   return result;
 }

--- a/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
+++ b/src/openassetio-python/cmodule/src/hostApi/ManagerBinding.cpp
@@ -235,28 +235,157 @@ void registerManager(const py::module& mod) {
            py::arg("defaultEntityAccess"), py::arg("context").none(false),
            py::arg("successCallback"), py::arg("errorCallback"),
            py::call_guard<py::gil_scoped_release>{})
-      .def("getWithRelationship", &Manager::getWithRelationship, py::arg("entityReferences"),
-           py::arg("relationshipTraitsData").none(false), py::arg("pageSize"),
-           py::arg("relationsAccess"), py::arg("context").none(false), py::arg("successCallback"),
+      .def("getWithRelationship",
+           py::overload_cast<const EntityReferences&, const trait::TraitsDataPtr&, size_t,
+                             access::RelationsAccess, const ContextConstPtr&,
+                             const Manager::RelationshipQuerySuccessCallback&,
+                             const Manager::BatchElementErrorCallback&, const trait::TraitSet&>(
+               &Manager::getWithRelationship),
+           py::arg("entityReferences"), py::arg("relationshipTraitsData"), py::arg("pageSize"),
+           py::arg("relationsAccess").none(false), py::arg("context"), py::arg("successCallback"),
            py::arg("errorCallback"), py::arg("resultTraitSet") = trait::TraitSet{},
            py::call_guard<py::gil_scoped_release>{})
+      // TODO(DF): Technically we shouldn't need this overload,
+      // since we can use a similar trick to C++ to default the
+      // appropriate overload's tag parameter, e.g.
+      // `py::arg("errorPolicyTag") = {}`. However, this causes a
+      // memory leak in pybind11.
+      .def(
+          "getWithRelationship",
+          [](Manager& self, const EntityReference& entityReference,
+             const trait::TraitsDataPtr& relationshipTraitsData, size_t pageSize,
+             const access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+             const trait::TraitSet& resultTraitSet) {
+            return self.getWithRelationship(entityReference, relationshipTraitsData, pageSize,
+                                            relationsAccess, context, resultTraitSet);
+          },
+          py::arg("entityReference"), py::arg("relationshipTraitsData").none(false),
+          py::arg("pageSize"), py::arg("relationsAccess"), py::arg("context").none(false),
+          py::arg("resultTraitSet"), py::call_guard<py::gil_scoped_release>{})
+      .def(
+          "getWithRelationship",
+          [](Manager& self, const EntityReferences& entityReferences,
+             const trait::TraitsDataPtr& relationshipTraitsData, size_t pageSize,
+             const access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+             const trait::TraitSet& resultTraitSet) {
+            return self.getWithRelationship(entityReferences, relationshipTraitsData, pageSize,
+                                            relationsAccess, context, resultTraitSet);
+          },
+          py::arg("entityReferences"), py::arg("relationshipTraitsData").none(false),
+          py::arg("pageSize"), py::arg("relationsAccess"), py::arg("context").none(false),
+          py::arg("resultTraitSet"), py::call_guard<py::gil_scoped_release>{})
+      .def("getWithRelationship",
+           py::overload_cast<const EntityReference&, const trait::TraitsDataPtr&, size_t,
+                             access::RelationsAccess, const ContextConstPtr&,
+                             const trait::TraitSet&,
+                             const Manager::BatchElementErrorPolicyTag::Exception&>(
+               &Manager::getWithRelationship),
+           py::arg("entityReference"), py::arg("relationshipTraitsData"), py::arg("pageSize"),
+           py::arg("relationsAccess").none(false), py::arg("context"), py::arg("resultTraitSet"),
+           py::arg("errorPolicyTag"), py::call_guard<py::gil_scoped_release>{})
+      .def("getWithRelationship",
+           py::overload_cast<const EntityReference&, const trait::TraitsDataPtr&, size_t,
+                             access::RelationsAccess, const ContextConstPtr&,
+                             const trait::TraitSet&,
+                             const Manager::BatchElementErrorPolicyTag::Variant&>(
+               &Manager::getWithRelationship),
+           py::arg("entityReference"), py::arg("relationshipTraitsData"), py::arg("pageSize"),
+           py::arg("relationsAccess").none(false), py::arg("context"), py::arg("resultTraitSet"),
+           py::arg("errorPolicyTag"), py::call_guard<py::gil_scoped_release>{})
+      .def("getWithRelationship",
+           py::overload_cast<const EntityReferences&, const trait::TraitsDataPtr&, size_t,
+                             access::RelationsAccess, const ContextConstPtr&,
+                             const trait::TraitSet&,
+                             const Manager::BatchElementErrorPolicyTag::Exception&>(
+               &Manager::getWithRelationship),
+           py::arg("entityReferences"), py::arg("relationshipTraitsData"), py::arg("pageSize"),
+           py::arg("relationsAccess").none(false), py::arg("context"), py::arg("resultTraitSet"),
+           py::arg("errorPolicyTag"), py::call_guard<py::gil_scoped_release>{})
+      .def("getWithRelationship",
+           py::overload_cast<const EntityReferences&, const trait::TraitsDataPtr&, size_t,
+                             access::RelationsAccess, const ContextConstPtr&,
+                             const trait::TraitSet&,
+                             const Manager::BatchElementErrorPolicyTag::Variant&>(
+               &Manager::getWithRelationship),
+           py::arg("entityReferences"), py::arg("relationshipTraitsData"), py::arg("pageSize"),
+           py::arg("relationsAccess").none(false), py::arg("context"), py::arg("resultTraitSet"),
+           py::arg("errorPolicyTag"), py::call_guard<py::gil_scoped_release>{})
+      .def("getWithRelationships",
+           py::overload_cast<const EntityReference&, const trait::TraitsDatas&, size_t,
+                             const access::RelationsAccess, const ContextConstPtr&,
+                             const Manager::RelationshipQuerySuccessCallback&,
+                             const Manager::BatchElementErrorCallback&, const trait::TraitSet&>(
+               &Manager::getWithRelationships),
+           py::arg("entityReference"), py::arg("relationshipTraitsDatas"), py::arg("pageSize"),
+           py::arg("relationsAccess").none(false), py::arg("context"), py::arg("successCallback"),
+           py::arg("errorCallback"), py::arg("resultTraitSet") = trait::TraitSet{},
+           py::call_guard<py::gil_scoped_release>{})
+      // TODO(DF): Technically we shouldn't need this overload,
+      // since we can use a similar trick to C++ to default the
+      // appropriate overload's tag parameter, e.g.
+      // `py::arg("errorPolicyTag") = {}`. However, this causes a
+      // memory leak in pybind11.
+      .def(
+          "getWithRelationships",
+          [](Manager& self, const EntityReference& entityReference,
+             const trait::TraitsDataPtr& relationshipTraitsData, size_t pageSize,
+             const access::RelationsAccess relationsAccess, const ContextConstPtr& context,
+             const trait::TraitSet& resultTraitSet) {
+            return self.getWithRelationships(entityReference, relationshipTraitsData, pageSize,
+                                             relationsAccess, context, resultTraitSet);
+          },
+          py::arg("entityReference"), py::arg("relationshipTraitsData"), py::arg("pageSize"),
+          py::arg("relationsAccess"), py::arg("context").none(false), py::arg("resultTraitSet"),
+          py::call_guard<py::gil_scoped_release>{})
       .def(
           "getWithRelationships",
           [](Manager& self, const EntityReference& entityReference,
              const trait::TraitsDatas& relationshipTraitsDatas, size_t pageSize,
              const access::RelationsAccess relationsAccess, const ContextConstPtr& context,
-             const Manager::RelationshipQuerySuccessCallback& successCallback,
-             const Manager::BatchElementErrorCallback& errorCallback,
              const trait::TraitSet& resultTraitSet) {
             validateTraitsDatas(relationshipTraitsDatas);
-            self.getWithRelationships(entityReference, relationshipTraitsDatas, pageSize,
-                                      relationsAccess, context, successCallback, errorCallback,
-                                      resultTraitSet);
+            return self.getWithRelationships(entityReference, relationshipTraitsDatas, pageSize,
+                                             relationsAccess, context, resultTraitSet);
           },
           py::arg("entityReference"), py::arg("relationshipTraitsDatas"), py::arg("pageSize"),
-          py::arg("relationsAccess"), py::arg("context").none(false), py::arg("successCallback"),
-          py::arg("errorCallback"), py::arg("resultTraitSet") = trait::TraitSet{},
+          py::arg("relationsAccess"), py::arg("context").none(false), py::arg("resultTraitSet"),
           py::call_guard<py::gil_scoped_release>{})
+      .def("getWithRelationships",
+           py::overload_cast<const EntityReference&, const trait::TraitsDataPtr&, size_t,
+                             access::RelationsAccess, const ContextConstPtr&,
+                             const trait::TraitSet&,
+                             const Manager::BatchElementErrorPolicyTag::Exception&>(
+               &Manager::getWithRelationships),
+           py::arg("entityReference"), py::arg("relationshipTraitsData"), py::arg("pageSize"),
+           py::arg("relationsAccess").none(false), py::arg("context"), py::arg("resultTraitSet"),
+           py::arg("errorPolicyTag"), py::call_guard<py::gil_scoped_release>{})
+      .def("getWithRelationships",
+           py::overload_cast<const EntityReference&, const trait::TraitsDataPtr&, size_t,
+                             access::RelationsAccess, const ContextConstPtr&,
+                             const trait::TraitSet&,
+                             const Manager::BatchElementErrorPolicyTag::Variant&>(
+               &Manager::getWithRelationships),
+           py::arg("entityReference"), py::arg("relationshipTraitsData"), py::arg("pageSize"),
+           py::arg("relationsAccess").none(false), py::arg("context"), py::arg("resultTraitSet"),
+           py::arg("errorPolicyTag"), py::call_guard<py::gil_scoped_release>{})
+      .def("getWithRelationships",
+           py::overload_cast<const EntityReference&, const trait::TraitsDatas&, size_t,
+                             access::RelationsAccess, const ContextConstPtr&,
+                             const trait::TraitSet&,
+                             const Manager::BatchElementErrorPolicyTag::Exception&>(
+               &Manager::getWithRelationships),
+           py::arg("entityReference"), py::arg("relationshipTraitsDatas"), py::arg("pageSize"),
+           py::arg("relationsAccess").none(false), py::arg("context"), py::arg("resultTraitSet"),
+           py::arg("errorPolicyTag"), py::call_guard<py::gil_scoped_release>{})
+      .def("getWithRelationships",
+           py::overload_cast<const EntityReference&, const trait::TraitsDatas&, size_t,
+                             access::RelationsAccess, const ContextConstPtr&,
+                             const trait::TraitSet&,
+                             const Manager::BatchElementErrorPolicyTag::Variant&>(
+               &Manager::getWithRelationships),
+           py::arg("entityReference"), py::arg("relationshipTraitsDatas"), py::arg("pageSize"),
+           py::arg("relationsAccess").none(false), py::arg("context"), py::arg("resultTraitSet"),
+           py::arg("errorPolicyTag"), py::call_guard<py::gil_scoped_release>{})
       .def(
           "preflight",
           [](Manager& self, const EntityReferences& entityReferences,

--- a/src/openassetio-python/tests/cmodule/gil/test_manager_gil.py
+++ b/src/openassetio-python/tests/cmodule/gil/test_manager_gil.py
@@ -127,11 +127,9 @@ class Test_Manager_gil:
     def test_flushCaches(self, a_threaded_manager):
         a_threaded_manager.flushCaches()
 
-    def test_getWithRelationship(self, a_threaded_manager, a_traits_data, a_context):
-        # Defend against forgetting to include convenience signatures in
-        # this test, once added.
-        assert "Overloaded" not in a_threaded_manager.getWithRelationship.__doc__
-
+    def test_getWithRelationship(
+        self, a_threaded_manager, an_entity_reference, a_traits_data, a_context
+    ):
         a_threaded_manager.getWithRelationship(
             [],
             a_traits_data,
@@ -142,11 +140,39 @@ class Test_Manager_gil:
             fail,
         )
 
-    def test_getWithRelationships(self, a_threaded_manager, an_entity_reference, a_context):
-        # Defend against forgetting to include convenience signatures in
-        # this test, once added.
-        assert "Overloaded" not in a_threaded_manager.getWithRelationships.__doc__
+        tag = Manager.BatchElementErrorPolicyTag
 
+        a_threaded_manager.getWithRelationship(
+            an_entity_reference,
+            a_traits_data,
+            1,
+            access.RelationsAccess.kRead,
+            a_context,
+            set(),
+            tag.kVariant,
+        )
+
+        a_threaded_manager.getWithRelationship(
+            an_entity_reference,
+            a_traits_data,
+            1,
+            access.RelationsAccess.kRead,
+            a_context,
+            set(),
+            tag.kException,
+        )
+
+        a_threaded_manager.getWithRelationship(
+            [], a_traits_data, 1, access.RelationsAccess.kRead, a_context, set(), tag.kVariant
+        )
+
+        a_threaded_manager.getWithRelationship(
+            [], a_traits_data, 1, access.RelationsAccess.kRead, a_context, set(), tag.kException
+        )
+
+    def test_getWithRelationships(
+        self, a_threaded_manager, an_entity_reference, a_traits_data, a_context
+    ):
         a_threaded_manager.getWithRelationships(
             an_entity_reference,
             [],
@@ -155,6 +181,48 @@ class Test_Manager_gil:
             a_context,
             fail,
             fail,
+        )
+
+        tag = Manager.BatchElementErrorPolicyTag
+
+        a_threaded_manager.getWithRelationships(
+            an_entity_reference,
+            a_traits_data,
+            1,
+            access.RelationsAccess.kRead,
+            a_context,
+            set(),
+            tag.kVariant,
+        )
+
+        a_threaded_manager.getWithRelationships(
+            an_entity_reference,
+            a_traits_data,
+            1,
+            access.RelationsAccess.kRead,
+            a_context,
+            set(),
+            tag.kException,
+        )
+
+        a_threaded_manager.getWithRelationships(
+            an_entity_reference,
+            [],
+            1,
+            access.RelationsAccess.kRead,
+            a_context,
+            set(),
+            tag.kVariant,
+        )
+
+        a_threaded_manager.getWithRelationships(
+            an_entity_reference,
+            [],
+            1,
+            access.RelationsAccess.kRead,
+            a_context,
+            set(),
+            tag.kException,
         )
 
     def test_hasCapability(self, a_threaded_manager):

--- a/src/openassetio-python/tests/package/hostApi/test_manager.py
+++ b/src/openassetio-python/tests/package/hostApi/test_manager.py
@@ -975,6 +975,12 @@ class FakeEntityReferencePagerInterface(EntityReferencePagerInterface):
         pass
 
 
+# The getWithRelationship tests are more repetitive than most tests
+# in this suite. They are unable to make use of the test
+# automation that we have written for the conveniences signatures, as
+# the arguments for getWithRelationship are not in the standard format.
+
+
 class Test_Manager_getWithRelationship_with_callback_signiature:
     def test_wraps_the_corresponding_method_of_the_held_interface(
         self,


### PR DESCRIPTION
Conveniences for exceptional and variant based error-object modes for the GetWithRelationship(s) methods, for both singular and batch variations.

## Description

Closes # (issue)

- [ ] I have updated the release notes.
- [ ] I have updated all relevant user documentation.

## Reviewer Notes

<!--- Provide any notes to the reviewer that might help them more easily
      understand the changeset. --->

## Test Instructions

<!--- Provide instructions to the reviewer on how to explicitly test
      these changes. --->
