### PR TITLE
Enable tomlplusplus exceptions explicitly

### DIFF
--- a/resources/build/conanfile.py
+++ b/resources/build/conanfile.py
@@ -62,3 +62,5 @@ class OpenAssetIOConan(ConanFile):
         # Enable optimising patterns with additional compile step.
         self.options["pcre2"].support_jit = True
 
+        self.options["tomlplusplus"].exceptions = True
+


### PR DESCRIPTION
A recipe update caused tomlplusplus exceptions not to be enabled by default.